### PR TITLE
Increased CoreClock to 30Mhz at zero flash waitstates

### DIFF
--- a/cmsis/system_LPC8xx.h
+++ b/cmsis/system_LPC8xx.h
@@ -112,11 +112,12 @@ __attribute__((always_inline)) void __delayticks(unsigned int ticks);
 // </e>
 */
 
-// 20 MHz main clock via PLL and internal RC oscillator
-// This is the maximum CPU clock frequency at zero waitstate flash access.
+// 30 MHz main clock via PLL and internal RC oscillator
+// According to the NXP tech support to access time of the internal flash
+// is 24ns and zero waitstate access is still possible at 30 Mhz.
 //
 // PLL is set to 60 MHz
-// AHBClkdiv divides the clock by 3
+// AHBClkdiv divides the clock by 2
 
 #define CLOCK_SETUP           1
 #define SYSOSCCTRL_Val        0x00000000              // Reset: 0x000
@@ -124,7 +125,7 @@ __attribute__((always_inline)) void __delayticks(unsigned int ticks);
 #define SYSPLLCTRL_Val        0x00000024              // Reset: 0x000
 #define SYSPLLCLKSEL_Val      0x00000000              // Reset: 0x000
 #define MAINCLKSEL_Val        0x00000003              // Reset: 0x000
-#define SYSAHBCLKDIV_Val      0x00000003              // Reset: 0x001
+#define SYSAHBCLKDIV_Val      0x00000002              // Reset: 0x001
 
 
 

--- a/src/system_LPC8xx.c
+++ b/src/system_LPC8xx.c
@@ -165,7 +165,7 @@ void SystemInit (void) {
 
   LPC_SYSCON->SYSAHBCLKDIV  = SYSAHBCLKDIV_Val;
 
-#if __SYSTEM_CLOCK <= 20000000
+#if __SYSTEM_CLOCK <= 30000000
   LPC_FLASHCTRL->FLASHCFG=0;		/* Set flash waitstates to zero if core clock is <=20 Mhz. Default is 1 waitstate */
 #endif
 


### PR DESCRIPTION
The NXP Tech support confirmed that the access time of the internal LPC810 flash is 24ns and therefore zero waitstate access is also possible at 30 MHz -> Increased CoreClock to 30 Mhz.
