### PR TITLE
Need to align end of .text segment for preinitialised data section

### DIFF
--- a/src/blinky.ld
+++ b/src/blinky.ld
@@ -21,10 +21,11 @@ SECTIONS
         KEEP(*(.after_vectors))
         *(.text*)
         *(.rodata*)
+        . = ALIGN(4);
         _etext = .;
     } > FLASH
 
-    .data : AT (ADDR(.text) + SIZEOF(.text))
+    .data : AT (_etext)
     {
         _data = .;
         *(vtable)


### PR DESCRIPTION
Issues with preinitialised data if the copy in flash is not aligned.
