### PR TITLE
Fix function call in UART

### DIFF
--- a/src/uart.c
+++ b/src/uart.c
@@ -124,7 +124,7 @@ void uart1SendChar(char buffer)
 void uart1Send(char *buffer, uint32_t length)
 {
   while (length != 0) {
-    uart1_snd_chr(*buffer);
+    uart1SendChar(*buffer);
     buffer++;
     length--;
   }
@@ -171,7 +171,7 @@ void uart2SendChar(char buffer)
 void uart2Send(char *buffer, uint32_t length)
 {
   while (length != 0) {
-    uart2_snd_chr(*buffer);
+    uart2SendChar(*buffer);
     buffer++;
     length--;
   }


### PR DESCRIPTION
When I pulled over the added UART functionality it was on a personal branch with a different formatting style for the function signatures. A couple of these didn't get converted to follow the styling in the master branch.

Not really sure how this was compiling but would have defiantly been a runtime error.