### PR TITLE
LPC8xx.h - LPC_MRT->IRQ_FLAG address wrong

### DIFF
--- a/cmsis/LPC8xx.h
+++ b/cmsis/LPC8xx.h
@@ -378,7 +378,7 @@ __IO uint32_t STAT;
 
 typedef struct {
   MRT_Channel_cfg_Type Channel[4]; 		
-   uint32_t Reserved0[1]; 				
+   uint32_t Reserved0[45]; 				
   __IO uint32_t IDLE_CH; 			
   __IO uint32_t IRQ_FLAG; 						
 } LPC_MRT_TypeDef;


### PR DESCRIPTION
See https://www.lpcware.com/content/forum/lpcmrt-irqflag-address-wrong
In LPC_MRT_TypeDef struct, change Reserved0[1] into Reserved0[45]